### PR TITLE
Remove requirement for "predict_proba" on base classifiers when it is not needed (Issue #44)

### DIFF
--- a/deslib/dcs/a_posteriori.py
+++ b/deslib/dcs/a_posteriori.py
@@ -88,6 +88,8 @@ class APosteriori(DCS):
                                           selection_method=selection_method,
                                           diff_thresh=diff_thresh,
                                           rng=rng)
+        self._check_predict_proba()
+
         self.name = 'A Posteriori'
 
     def fit(self, X, y):

--- a/deslib/dcs/a_priori.py
+++ b/deslib/dcs/a_priori.py
@@ -79,6 +79,8 @@ class APriori(DCS):
                                       selection_method=selection_method,
                                       diff_thresh=diff_thresh,
                                       rng=rng)
+        self._check_predict_proba()
+
         self.name = 'A Priori'
 
     def fit(self, X, y):

--- a/deslib/dcs/lca.py
+++ b/deslib/dcs/lca.py
@@ -28,7 +28,7 @@ class LCA(DCS):
     ----------
     pool_classifiers : list of classifiers
                        The generated_pool of classifiers trained for the corresponding classification problem.
-                       The classifiers should support methods "predict" and "predict_proba".
+                       The classifiers should support the method "predict".
 
     k : int (Default = 7)
         Number of neighbors used to estimate the competence of the base classifiers.

--- a/deslib/dcs/mcb.py
+++ b/deslib/dcs/mcb.py
@@ -27,7 +27,7 @@ class MCB(DCS):
     ----------
     pool_classifiers : list of classifiers
                        The generated_pool of classifiers trained for the corresponding classification problem.
-                       The classifiers should support methods "predict" and "predict_proba".
+                       The classifiers should support the method "predict".
 
     k : int (Default = 7)
         Number of neighbors used to estimate the competence of the base classifiers.

--- a/deslib/dcs/mla.py
+++ b/deslib/dcs/mla.py
@@ -25,7 +25,7 @@ class MLA(DCS):
     ----------
     pool_classifiers : list of classifiers
                        The generated_pool of classifiers trained for the corresponding classification problem.
-                       The classifiers should support methods "predict" and "predict_proba".
+                       The classifiers should support the method "predict".
 
     k : int (Default = 7)
         Number of neighbors used to estimate the competence of the base classifiers.

--- a/deslib/dcs/ola.py
+++ b/deslib/dcs/ola.py
@@ -26,7 +26,7 @@ class OLA(DCS):
     ----------
     pool_classifiers : list of classifiers
                        The generated_pool of classifiers trained for the corresponding classification problem.
-                       The classifiers should support methods "predict" and "predict_proba".
+                       The classifiers should support the method "predict".
 
     k : int (Default = 7)
         Number of neighbors used to estimate the competence of the base classifiers.

--- a/deslib/dcs/rank.py
+++ b/deslib/dcs/rank.py
@@ -26,7 +26,7 @@ class Rank(DCS):
     ----------
     pool_classifiers : list of classifiers
                        The generated_pool of classifiers trained for the corresponding classification problem.
-                       The classifiers should support methods "predict" and "predict_proba".
+                       The classifiers should support the method "predict".
 
     k : int (Default = 7)
         Number of neighbors used to estimate the competence of the base classifiers.

--- a/deslib/des/des_clustering.py
+++ b/deslib/des/des_clustering.py
@@ -25,7 +25,7 @@ class DESClustering(DES):
     ----------
     pool_classifiers : list of classifiers
                        The generated_pool of classifiers trained for the corresponding classification problem.
-                       The classifiers should support methods "predict" and "predict_proba".
+                       The classifiers should support the method "predict".
 
     k : int (Default = 5)
         Number of neighbors used to estimate the competence of the base classifiers.

--- a/deslib/des/des_knn.py
+++ b/deslib/des/des_knn.py
@@ -84,7 +84,7 @@ class DESKNN(DES):
                                      mode=mode)
 
         self.N = int(self.n_classifiers * pct_accuracy)
-        self.J = int(self.n_classifiers * pct_diversity)
+        self.J = int(np.ceil(self.n_classifiers * pct_diversity))
         self.more_diverse = more_diverse
         self.name = 'Dynamic Ensemble Selection-KNN (DES-KNN)'
 

--- a/deslib/des/des_knn.py
+++ b/deslib/des/des_knn.py
@@ -21,8 +21,9 @@ class DESKNN(DES):
 
     Parameters
     ----------
-    pool_classifiers : type, the generated_pool of classifiers trained for the corresponding
-    classification problem.
+    pool_classifiers : list of classifiers
+                       The generated_pool of classifiers trained for the corresponding classification problem.
+                       The classifiers should support the method "predict".
 
     k : int (Default = 5)
         Number of neighbors used to estimate the competence of the base classifiers.

--- a/deslib/des/des_p.py
+++ b/deslib/des/des_p.py
@@ -22,7 +22,7 @@ class DESP(DES):
     ----------
     pool_classifiers : list of classifiers
                        The generated_pool of classifiers trained for the corresponding classification problem.
-                       The classifiers should support methods "predict" and "predict_proba".
+                       The classifiers should support the method "predict".
 
     k : int (Default = 7)
         Number of neighbors used to estimate the competence of the base classifiers.

--- a/deslib/des/knop.py
+++ b/deslib/des/knop.py
@@ -72,6 +72,8 @@ class KNOP(DES):
                                    with_IH=with_IH,
                                    safe_k=safe_k,
                                    IH_rate=IH_rate)
+        self._check_predict_proba()
+
         self.weighted = weighted
         self.name = 'K-Nearest Output Profiles (KNOP)'
 

--- a/deslib/des/knora_e.py
+++ b/deslib/des/knora_e.py
@@ -22,6 +22,10 @@ class KNORAE(DES):
     
     Parameters
     ----------
+    pool_classifiers : list of classifiers
+                       The generated_pool of classifiers trained for the corresponding classification problem.
+                       The classifiers should support the method "predict".
+
     k : int (Default = 7)
         Number of neighbors used to estimate the competence of the base classifiers.
 

--- a/deslib/des/knora_u.py
+++ b/deslib/des/knora_u.py
@@ -21,6 +21,10 @@ class KNORAU(DES):
 
     Parameters
     ----------
+    pool_classifiers : list of classifiers
+                       The generated_pool of classifiers trained for the corresponding classification problem.
+                       The classifiers should support the method "predict".
+
     k : int (Default = 7)
         Number of neighbors used to estimate the competence of the base classifiers.
 

--- a/deslib/des/meta_des.py
+++ b/deslib/des/meta_des.py
@@ -97,6 +97,7 @@ class METADES(DES):
         super(METADES, self).__init__(pool_classifiers, k, DFP=DFP,
                                       with_IH=with_IH, safe_k=safe_k, IH_rate=IH_rate, mode=mode)
 
+        self._check_predict_proba()
         self._check_input_parameters(Hc, gamma, meta_classifier)
 
         self.name = 'META-DES'

--- a/deslib/des/probabilistic.py
+++ b/deslib/des/probabilistic.py
@@ -70,6 +70,8 @@ class Probabilistic(DES):
         super(Probabilistic, self).__init__(pool_classifiers, k, DFP=DFP, with_IH=with_IH, safe_k=safe_k,
                                             IH_rate=IH_rate,
                                             mode=mode)
+        self._check_predict_proba()
+
         self.C_src = None
         self.selection_threshold = selection_threshold
 

--- a/deslib/tests/dcs/test_a_posteriori.py
+++ b/deslib/tests/dcs/test_a_posteriori.py
@@ -1,4 +1,5 @@
 import pytest
+from sklearn.linear_model import Perceptron
 
 from deslib.dcs.a_posteriori import APosteriori
 from deslib.tests.examples_test import *
@@ -68,7 +69,20 @@ def test_estimate_competence_diff_target(index):
     assert np.isclose(competences, expected).all()
 
 
+# Check if the fit method is pre-calculating the classifier scores correctly
 def test_fit():
     a_posteriori_test = APosteriori(create_pool_classifiers())
     a_posteriori_test.fit(X_dsel_ex1, y_dsel_ex1)
     assert np.isclose(a_posteriori_test.dsel_scores, [0.5, 0.5, 1.0, 0.0, 0.33, 0.67]).all()
+
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# Should raise an exception when the base classifier cannot estimate posterior probabilities (predict_proba)
+# Using Perceptron classifier as it does not implements the predict_proba method.
+def test_not_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    with pytest.raises(ValueError):
+        APosteriori([clf1, clf1])

--- a/deslib/tests/dcs/test_a_priori.py
+++ b/deslib/tests/dcs/test_a_priori.py
@@ -1,5 +1,5 @@
 import pytest
-
+from sklearn.linear_model import Perceptron
 from deslib.dcs.a_priori import APriori
 from deslib.tests.examples_test import *
 
@@ -71,3 +71,15 @@ def test_fit():
     a_priori_test = APriori(create_pool_classifiers())
     a_priori_test.fit(X_dsel_ex1, y_dsel_ex1)
     assert np.isclose(a_priori_test.dsel_scores, [0.5, 0.5, 1.0, 0.0, 0.33, 0.67]).all()
+
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# Should raise an exception when the base classifier cannot estimate posterior probabilities (predict_proba)
+# Using Perceptron classifier as it does not implements the predict_proba method.
+def test_not_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    with pytest.raises(ValueError):
+        APriori([clf1, clf1])

--- a/deslib/tests/dcs/test_lca.py
+++ b/deslib/tests/dcs/test_lca.py
@@ -1,5 +1,5 @@
 import pytest
-
+from sklearn.linear_model import Perceptron
 from deslib.dcs.lca import LCA
 from deslib.tests.examples_test import *
 
@@ -38,3 +38,14 @@ def test_estimate_competence_diff_target(index):
 
     competences = lca.estimate_competence(query.reshape(1, -1))
     assert np.isclose(competences, expected).all()
+
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# In this case the test should not raise an error since this class does not require base classifiers that
+# can estimate probabilities
+def test_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    LCA([clf1, clf1])

--- a/deslib/tests/dcs/test_mcb.py
+++ b/deslib/tests/dcs/test_mcb.py
@@ -1,5 +1,5 @@
 import pytest
-
+from sklearn.linear_model import Perceptron
 from deslib.dcs.mcb import MCB
 from deslib.tests.examples_test import *
 
@@ -95,3 +95,14 @@ def test_estimate_competence3(index, expected):
     mcb_test.BKS_dsel = bks_dsel_ex3
     competences = mcb_test.estimate_competence(query.reshape(1, -1))
     assert np.isclose(competences, expected).all()
+
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# In this case the test should not raise an error since this class does not require base classifiers that
+# can estimate probabilities
+def test_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    MCB([clf1, clf1])

--- a/deslib/tests/dcs/test_mla.py
+++ b/deslib/tests/dcs/test_mla.py
@@ -1,4 +1,5 @@
 import pytest
+from sklearn.linear_model import Perceptron
 
 from deslib.dcs.mla import MLA
 from deslib.tests.examples_test import *
@@ -86,3 +87,14 @@ def test_estimate_competence_diff_target(index):
 
     competences = mla_test.estimate_competence(query.reshape(1, -1))
     assert np.isclose(competences, expected).all()
+
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# In this case the test should not raise an error since this class does not require base classifiers that
+# can estimate probabilities
+def test_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    MLA([clf1, clf1])

--- a/deslib/tests/dcs/test_ola.py
+++ b/deslib/tests/dcs/test_ola.py
@@ -1,4 +1,5 @@
 import pytest
+from sklearn.linear_model import Perceptron
 
 from deslib.dcs.ola import OLA
 from deslib.tests.examples_test import *
@@ -16,3 +17,14 @@ def test_estimate_competence(index, expected):
     query = np.array([1, 1])
     competences = ola_test.estimate_competence(query.reshape(1, -1))
     assert np.isclose(competences, expected).all()
+
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# In this case the test should not raise an error since this class does not require base classifiers that
+# can estimate probabilities
+def test_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    OLA([clf1, clf1])

--- a/deslib/tests/dcs/test_rank.py
+++ b/deslib/tests/dcs/test_rank.py
@@ -1,4 +1,5 @@
 import pytest
+from sklearn.linear_model import Perceptron
 
 from deslib.dcs.rank import Rank
 from deslib.tests.examples_test import *
@@ -16,5 +17,17 @@ def test_estimate_competence(index, expected):
     query = np.array([1, 1])
     competences = rank_test.estimate_competence(query.reshape(1, -1))
     assert np.isclose(competences, expected).all()
+
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# In this case the test should not raise an error since this class does not require base classifiers that
+# can estimate probabilities
+def test_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    Rank([clf1, clf1])
+
 
 

--- a/deslib/tests/des/test_des_clustering.py
+++ b/deslib/tests/des/test_des_clustering.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+from sklearn.linear_model import Perceptron
 
 from deslib.des.des_clustering import DESClustering
 from deslib.tests.examples_test import create_pool_classifiers, X_dsel_ex1, y_dsel_ex1
@@ -131,3 +132,14 @@ def test_diversity_metric_DF():
 def test_diversity_metric_ratio():
     test = DESClustering(create_pool_classifiers() * 10, metric='ratio')
     assert test.diversity_func == ratio_errors
+
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# In this case the test should not raise an error since this class does not require base classifiers that
+# can estimate probabilities
+def test_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    DESClustering([clf1, clf1])

--- a/deslib/tests/des/test_des_knn.py
+++ b/deslib/tests/des/test_des_knn.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+from sklearn.linear_model import Perceptron
 
 from deslib.des.des_knn import DESKNN
 from deslib.tests.examples_test import create_pool_classifiers
@@ -157,3 +158,14 @@ def test_classify_instance():
 
     predicted = des_knn_test.classify_instance(query)
     assert predicted == 0
+
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# In this case the test should not raise an error since this class does not require base classifiers that
+# can estimate probabilities
+def test_predict_proba():
+    X = np.random.randn(5, 5)
+    y = np.array([0, 1, 0, 0, 0])
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    DESKNN([clf1, clf1, clf1])

--- a/deslib/tests/des/test_desp.py
+++ b/deslib/tests/des/test_desp.py
@@ -2,6 +2,7 @@ import pytest
 
 from deslib.des.des_p import DESP
 from deslib.tests.examples_test import *
+from sklearn.linear_model import Perceptron
 
 
 @pytest.mark.parametrize('index, expected', [(0, [0.57142857, 0.4285714, 0.57142857]),
@@ -85,3 +86,14 @@ def test_select_none_competent():
     competences = np.ones(des_p_test.n_classifiers) * 0.49
     indices = des_p_test.select(competences)
     assert indices == list(range(des_p_test.n_classifiers))
+
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# In this case the test should not raise an error since this class does not require base classifiers that
+# can estimate probabilities
+def test_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    DESP([clf1, clf1])

--- a/deslib/tests/des/test_knop.py
+++ b/deslib/tests/des/test_knop.py
@@ -1,5 +1,5 @@
 import pytest
-
+from sklearn.linear_model import Perceptron
 from deslib.des.knop import KNOP
 from deslib.tests.examples_test import *
 
@@ -58,5 +58,15 @@ def test_fit():
     assert np.array_equal(knop_test.roc_algorithm._fit_X, knop_test.dsel_scores)
 
 
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# Should raise an exception when the base classifier cannot estimate posterior probabilities (predict_proba)
+# Using Perceptron classifier as it does not implements the predict_proba method.
+def test_not_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    with pytest.raises(ValueError):
+        KNOP([clf1, clf1])
 
 

--- a/deslib/tests/des/test_knorae.py
+++ b/deslib/tests/des/test_knorae.py
@@ -2,6 +2,7 @@ import pytest
 
 from deslib.des.knora_e import KNORAE
 from deslib.tests.examples_test import *
+from sklearn.linear_model import Perceptron
 
 
 @pytest.mark.parametrize('index, expected', [(0, [1.0, 0.0, 1.0]),
@@ -52,5 +53,17 @@ def test_select_none_competent():
     indices = knora_e_test.select(competences)
 
     assert indices == list(range(knora_e_test.n_classifiers))
+
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# In this case the test should not raise an error since this class does not require base classifiers that
+# can estimate probabilities
+def test_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    KNORAE([clf1, clf1])
+
 
 

--- a/deslib/tests/des/test_knorau.py
+++ b/deslib/tests/des/test_knorau.py
@@ -2,6 +2,7 @@ import pytest
 
 from deslib.des.knora_u import KNORAU
 from deslib.tests.examples_test import *
+from sklearn.linear_model import Perceptron
 
 
 @pytest.mark.parametrize('index, expected', [(0, [4.0, 3.0, 4.0]),
@@ -59,6 +60,18 @@ def test_weights_zero():
 
     result = knora_u_test.select(query)
     assert np.array_equal(result, np.array([0, 1, 0]))
+
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# In this case the test should not raise an error since this class does not require base classifiers that
+# can estimate probabilities
+def test_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    KNORAU([clf1, clf1])
+
 
 
 

--- a/deslib/tests/des/test_meta_des.py
+++ b/deslib/tests/des/test_meta_des.py
@@ -96,3 +96,15 @@ def test_parameter_Hc(Hc):
 def test_parameter_gamma(gamma):
     with pytest.raises((ValueError, TypeError)):
         METADES(create_pool_classifiers(), gamma=gamma)
+
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# Should raise an exception when the base classifier cannot estimate posterior probabilities (predict_proba)
+# Using Perceptron classifier as it does not implements the predict_proba method.
+def test_not_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    with pytest.raises(ValueError):
+        METADES([clf1, clf1])

--- a/deslib/tests/des/test_probabilistic.py
+++ b/deslib/tests/des/test_probabilistic.py
@@ -1,5 +1,18 @@
+import pytest
+from sklearn.linear_model import Perceptron
 from deslib.des.probabilistic import Probabilistic, RRC, DESKL, Logarithmic, Exponential, MinimumDifference
 from deslib.tests.examples_test import *
+
+# Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
+# Should raise an exception when the base classifier cannot estimate posterior probabilities (predict_proba)
+# Using Perceptron classifier as it does not implements the predict_proba method.
+def test_not_predict_proba():
+    X = X_dsel_ex1
+    y = y_dsel_ex1
+    clf1 = Perceptron()
+    clf1.fit(X, y)
+    with pytest.raises(ValueError):
+        Probabilistic([clf1, clf1])
 
 
 # Being all zeros, no base classifier is deemed competent, so the system selects all of them
@@ -41,18 +54,22 @@ def test_select_threshold():
     assert np.array_equal(indices, expected)
 
 
+# Test the potential function calculation. The return value should be zero in this test.
 def test_potential_function_zeros():
     dists = np.zeros(10)
     value = Probabilistic.potential_func(dists)
     assert np.array_equal(value, np.ones(10))
 
 
+# Test the potential function calculation. Higher values for distances should obtain a lower value in the results
 def test_potential_function():
     dists = np.array([1.0, 0.5, 2, 0.33])
     value = Probabilistic.potential_func(dists)
     assert np.allclose(value, [0.3679, 0.7788, 0.0183, 0.8968], atol=0.001)
 
 
+# Test the estimate_competence method using a pre-calculated source of competence matrix. The final competence is
+# a result of the competence source and the result of the potential function model at each data point.
 def test_estimate_competence():
 
     query = np.atleast_2d([1, 1])

--- a/deslib/tests/test_base.py
+++ b/deslib/tests/test_base.py
@@ -112,18 +112,6 @@ def test_input_shape_fit():
         ds_test.fit(X, y)
 
 
-# Tests if the base estimators implements the predict proba function
-def test_predict_proba_exists():
-    query = np.array([[1.0, 1.0]])
-
-    X = X_dsel_ex1
-    y = y_dsel_ex1
-    clf1 = Perceptron()
-    clf1.fit(X, y)
-    with pytest.raises(ValueError):
-        DS([clf1, clf1])
-
-
 @pytest.mark.parametrize('index, expected', [(0, 0.42),
                                              (1, 0.28),
                                              (2, 0.28)])

--- a/deslib/tests/util/knn.py
+++ b/deslib/tests/util/knn.py
@@ -1,0 +1,7 @@
+import tensorflow as tf
+import numpy as np
+
+def fit(X, y):
+
+    neg_one = tf.constant(-1.0, dtype=tf.float64)
+    distances = tf.reduce_sum(tf.abs(tf.subtract(X_t, x_t)), 1)


### PR DESCRIPTION
Removing the requirements for "predict_proba" on base classifier for the following DS methods:

DCS:
- Overall Local Accuracy (OLA)
- Local Class Accuracy (LCA)
- Modified Local Accuracy (MLA)
- Multiple Classifier Behaviour (MCB)
- Modified Rank

DES:
- KNORA-Eliminate
- KNORA-Union
- DES-KNN
- DES Clustering
- DES-Performance (DES-P)