### PR TITLE
Change dsel_scores matrix shape 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 build
 dist
 DESlib.egg-info
+.idea

--- a/deslib/dcs/a_posteriori.py
+++ b/deslib/dcs/a_posteriori.py
@@ -9,11 +9,6 @@ import numpy as np
 from deslib.dcs.base import DCS
 
 
-#    This method works similarly to the LCA technique. The only difference is that it uses
-#    the scores obtained by the base classifiers as well as the distance between the test sample
-#    and each pattern in the region of competence are also considered in the competence estimation.
-
-
 class APosteriori(DCS):
     """A Posteriori Dynamic classifier selection.
 
@@ -147,7 +142,7 @@ class APosteriori(DCS):
                     target = self.DSEL_target[neighbor]
                     if target == predicted_label:
                         # get the posterior probability for the target class
-                        post_prob = self._get_scores_dsel(clf_index, neighbor)[target]
+                        post_prob = self.dsel_scores[neighbor, clf_index, target]
                         # weight by distance
                         result.append(post_prob * dists_normalized[counter])
                         # keep the distance for normalization

--- a/deslib/dcs/a_priori.py
+++ b/deslib/dcs/a_priori.py
@@ -129,7 +129,9 @@ class APriori(DCS):
                 for counter, index in enumerate(idx_neighbors):
                     target = self.DSEL_target[index]
                     # get the post_prob for the correct class
-                    post_prob = self._get_scores_dsel(clf_index, index)[target]
+                    #post_prob = self._get_scores_dsel(clf_index, index)[target]
+                    post_prob = self.dsel_scores[index, clf_index, target]
+
                     result[counter] = (post_prob * dists_normalized[counter])
 
                 competences[clf_index] = sum(result)/sum(dists_normalized)

--- a/deslib/des/knop.py
+++ b/deslib/des/knop.py
@@ -99,7 +99,9 @@ class KNOP(DES):
         y_ind = self.setup_label_encoder(y)
         self._set_dsel(X, y_ind)
         self.dsel_scores = self._preprocess_dsel_scores()
-        self._fit_region_competence(self.dsel_scores, y_ind, self.k)
+        # Reshape dsel_scores as a 2-D array for nearest neighbor calculations
+        dsel_output_profiles = self.dsel_scores.reshape(self.n_samples, self.n_classifiers * self.n_classes)
+        self._fit_region_competence(dsel_output_profiles, y_ind, self.k)
 
         return self
     

--- a/deslib/des/meta_des.py
+++ b/deslib/des/meta_des.py
@@ -141,7 +141,10 @@ class METADES(DES):
         self._set_dsel(X, y_ind)
         self._fit_region_competence(X, y_ind, self.k)
         self.dsel_scores = self._preprocess_dsel_scores()
-        self._fit_OP(self.dsel_scores, y_ind, self.Kp)
+
+        # Reshape dsel_scores as a 2-D array for nearest neighbor calculations
+        dsel_output_profiles = self.dsel_scores.reshape(self.n_samples, self.n_classifiers * self.n_classes)
+        self._fit_OP(dsel_output_profiles, y_ind, self.Kp)
 
         # check whether the meta-classifier was already trained
         # since it could have been pre-processed before
@@ -211,7 +214,7 @@ class METADES(DES):
         """
         # Meta-Features computation
         f1 = [self.processed_dsel[idx][clf_index] for idx in idx_neighbors]
-        f2 = [self._get_scores_dsel(clf_index, idx)[self.DSEL_target[idx]] for idx in idx_neighbors]
+        f2 = [self.dsel_scores[idx, clf_index, self.DSEL_target[idx]] for idx in idx_neighbors]
         f3 = np.mean(f1)
         f4 = [self.processed_dsel[idx][clf_index] for idx in idx_neighbors_op]
         # check with the classifier model how to compute f5

--- a/deslib/des/probabilistic.py
+++ b/deslib/des/probabilistic.py
@@ -263,9 +263,9 @@ class Logarithmic(Probabilistic):
         """
         C_src = np.zeros((self.n_samples, self.n_classifiers))
         for clf_index in range(self.n_classifiers):
-            supports = self._get_scores_dsel(clf_index)
-            support_correct = [supports[sample_idx, i] for sample_idx, i in enumerate(self.DSEL_target)]
-            support_correct = np.array(support_correct)
+            supports = self.dsel_scores[:, clf_index, :]
+            support_correct = supports[np.arange(self.n_samples), self.DSEL_target]
+
             C_src[:, clf_index] = log_func(self.n_classes, support_correct)
 
         return C_src
@@ -340,9 +340,9 @@ class Exponential(Probabilistic):
         """
         C_src = np.zeros((self.n_samples, self.n_classifiers))
         for clf_index in range(self.n_classifiers):
-            supports = self._get_scores_dsel(clf_index)
-            support_correct = [supports[sample_idx, i] for sample_idx, i in enumerate(self.DSEL_target)]
-            support_correct = np.array(support_correct)
+            supports = self.dsel_scores[:, clf_index, :]
+            support_correct = supports[np.arange(self.n_samples), self.DSEL_target]
+
             C_src[:, clf_index] = exponential_func(self.n_classes, support_correct)
         return C_src
 
@@ -415,7 +415,7 @@ class RRC(Probabilistic):
 
         for clf_index in range(self.n_classifiers):
             # Get supports for all samples in DSEL
-            supports = self._get_scores_dsel(clf_index)
+            supports = self.dsel_scores[:, clf_index, :]
             c_src[:, clf_index] = ccprmod(supports, self.DSEL_target)
 
         return c_src
@@ -494,7 +494,7 @@ class DESKL(Probabilistic):
 
         C_src = np.zeros((self.n_samples, self.n_classifiers))
         for clf_index in range(self.n_classifiers):
-            supports = self._get_scores_dsel(clf_index)
+            supports = self.dsel_scores[:, clf_index, :]
             is_correct = self.processed_dsel[:, clf_index]
             C_src[:, clf_index] = entropy_func(self.n_classes, supports, is_correct)
 
@@ -570,7 +570,7 @@ class MinimumDifference(Probabilistic):
         """
         C_src = np.zeros((self.n_samples, self.n_classifiers))
         for clf_index in range(self.n_classifiers):
-            supports = self._get_scores_dsel(clf_index)
+            supports = self.dsel_scores[:, clf_index, :]
             C_src[:, clf_index] = min_difference(supports, self.DSEL_target)
 
         return C_src

--- a/deslib/tests/dcs/test_a_posteriori.py
+++ b/deslib/tests/dcs/test_a_posteriori.py
@@ -82,7 +82,9 @@ def test_estimate_competence_diff_target(index):
 def test_fit():
     a_posteriori_test = APosteriori(create_pool_classifiers())
     a_posteriori_test.fit(X_dsel_ex1, y_dsel_ex1)
-    assert np.isclose(a_posteriori_test.dsel_scores, [0.5, 0.5, 1.0, 0.0, 0.33, 0.67]).all()
+    expected = np.array([[0.5, 0.5], [1.0, 0.0], [0.33, 0.67]])
+    expected = np.tile(expected, (15, 1, 1))
+    assert np.array_equal(a_posteriori_test.dsel_scores, expected)
 
 
 # Test if the class is raising an error when the base classifiers do not implements the predict_proba method.

--- a/deslib/tests/dcs/test_a_priori.py
+++ b/deslib/tests/dcs/test_a_priori.py
@@ -70,7 +70,9 @@ def test_estimate_competence2(index, expected):
 def test_fit():
     a_priori_test = APriori(create_pool_classifiers())
     a_priori_test.fit(X_dsel_ex1, y_dsel_ex1)
-    assert np.isclose(a_priori_test.dsel_scores, [0.5, 0.5, 1.0, 0.0, 0.33, 0.67]).all()
+    expected = np.array([[0.5, 0.5], [1.0, 0.0], [0.33, 0.67]])
+    expected = np.tile(expected, (15, 1, 1))
+    assert np.array_equal(a_priori_test.dsel_scores, expected)
 
 
 # Test if the class is raising an error when the base classifiers do not implements the predict_proba method.

--- a/deslib/tests/des/test_knop.py
+++ b/deslib/tests/des/test_knop.py
@@ -57,10 +57,15 @@ def test_weights_zero():
 def test_fit():
     knop_test = KNOP(create_pool_classifiers())
     knop_test.fit(X_dsel_ex1, y_dsel_ex1)
-    expected_scores = np.ones((15, 6)) * np.array([0.5, 0.5, 1.0, 0.0, 0.33, 0.67])
+    expected_scores = np.array([[0.5, 0.5], [1.0, 0.0], [0.33, 0.67]])
+    expected_scores = np.tile(expected_scores, (15, 1, 1))
+
     assert np.array_equal(expected_scores, knop_test.dsel_scores)
+
     # Assert the roc_algorithm is fitted to the scores (decision space) rather than the features (feature space)
-    assert np.array_equal(knop_test.roc_algorithm._fit_X, knop_test.dsel_scores)
+    expected_roc_data = knop_test.dsel_scores.reshape(knop_test.n_samples,
+                                                      knop_test.n_classifiers * knop_test.n_classes)
+    assert np.array_equal(knop_test.roc_algorithm._fit_X, expected_roc_data)
 
 
 # Test if the class is raising an error when the base classifiers do not implements the predict_proba method.

--- a/deslib/tests/des/test_probabilistic.py
+++ b/deslib/tests/des/test_probabilistic.py
@@ -3,6 +3,7 @@ from sklearn.linear_model import Perceptron
 from deslib.des.probabilistic import Probabilistic, RRC, DESKL, Logarithmic, Exponential, MinimumDifference
 from deslib.tests.examples_test import *
 
+
 # Test if the class is raising an error when the base classifiers do not implements the predict_proba method.
 # Should raise an exception when the base classifier cannot estimate posterior probabilities (predict_proba)
 # Using Perceptron classifier as it does not implements the predict_proba method.
@@ -122,7 +123,10 @@ The expected value should be: an np.array (4,1) with the values = [[0.7849], [0.
 
 def test_source_competence_rrc():
     rrc_test = RRC([create_base_classifier(return_value=1, return_prob=1.0)])
-    rrc_test.dsel_scores = np.array([[0.3, 0.6, 0.1], [1.0 / 3, 1.0 / 3, 1.0 / 3], [0.5, 0.2, 0.3], [0.5, 0.2, 0.3]])
+    rrc_test.dsel_scores = np.array([[[0.3, 0.6, 0.1],
+                                      [1.0 / 3, 1.0 / 3, 1.0 / 3],
+                                      [0.5, 0.2, 0.3],
+                                      [0.5, 0.2, 0.3]]]).reshape(4, 1, 3)  # 4 samples, 1 classifier and 3 classes
     rrc_test.DSEL_target = [1, 0, 0, 1]
     rrc_test.n_classes = 3
     rrc_test.n_samples = 4
@@ -131,19 +135,21 @@ def test_source_competence_rrc():
     assert np.allclose(C_src, expected, atol=0.01)
 
 
-""" Test the source_competence using the kullback leibler divergence method. Here we consider the same values 
-applied in the test_prob_functions.py to assert if the source_competence function call the ccprmod correctly
-and fill the competence source (C_src) with the correct results.
+""" Test the source_competence estimation for the Kullback-Leibler method. Here we consider the same values 
+applied in the test_prob_functions.py to assert if the source_competence function fill the competence source
+(C_src) with the correct results.
 
-The scores used are: [[0.3, 0.6, 0.1], [1.0 / 3, 1.0 / 3, 1.0 / 3], [0.5, 0.2, 0.3], [0.5, 0.2, 0.3]]
-The correct labels are: [1, 0, 0, 1]
-The expected value should be: an np.array (4,1) with the values = [[0.7849], [0.3328], [0.6428], [0.1194]]
+The scores used are: [[0.33, 0.33, 0.33], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
+The matrix with correct predictions is: [False, True, False]
+The expected value should be: an np.array (3,1) with the values = [[0.0], [1.0], [-1.0]]
 """
 
 
 def test_source_competence_kl():
     entropy_test = DESKL([create_base_classifier(return_value=1, return_prob=1.0)])
-    entropy_test.dsel_scores = np.array([[0.33, 0.33, 0.33], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+    entropy_test.dsel_scores = np.array([[[0.33, 0.33, 0.33],
+                                         [1.0, 0.0, 0.0],
+                                         [1.0, 0.0, 0.0]]]).reshape(3, 1, 3)  # 3 Samples, 1 classifier, 3 classes
     entropy_test.processed_dsel = np.array([[False], [True], [False]])
     entropy_test.n_classes = 3
     entropy_test.n_samples = 3
@@ -152,9 +158,9 @@ def test_source_competence_kl():
     assert np.allclose(C_src, expected, atol=0.01)
 
 
-""" Test the source_competence using the kullback leibler divergence method. Here we consider the same values 
-applied in the test_prob_functions.py to assert if the source_competence function call the ccprmod correctly
-and fill the competence source (C_src) with the correct results.
+""" Test the source_competence estimation for the Minimum difference  method. Here we consider the same values 
+applied in the test_prob_functions.py to assert if the source_competence function fill the competence source
+(C_src) with the correct results.
 
 The scores used are: [[0.3, 0.6, 0.1], [1.0 / 3, 1.0 / 3, 1.0 / 3], [0.5, 0.2, 0.3], [0.5, 0.2, 0.3]]
 The correct labels are: [1, 0, 0, 1]
@@ -164,18 +170,22 @@ The expected value should be: an np.array (4,1) with the values = [[0.7849], [0.
 
 def test_source_competence_minimum_difference():
     md_test = MinimumDifference([create_base_classifier(return_value=1, return_prob=1.0)])
-    md_test .dsel_scores = np.array([[0.3, 0.6, 0.1], [1.0 / 3, 1.0 / 3, 1.0 / 3], [0.5, 0.2, 0.3], [0.5, 0.2, 0.3]])
-    md_test .DSEL_target = [1, 0, 0, 1]
-    md_test .n_classes = 3
-    md_test .n_samples = 4
-    C_src = md_test .source_competence()
+    md_test.dsel_scores = np.array([[[0.3, 0.6, 0.1],
+                                    [1.0 / 3, 1.0 / 3, 1.0 / 3],
+                                    [0.5, 0.2, 0.3],
+                                    [0.5, 0.2, 0.3]]]).reshape(4, 1, 3)  # 4 samples, 1 classifier, 3 classes
+
+    md_test.DSEL_target = [1, 0, 0, 1]
+    md_test.n_classes = 3
+    md_test.n_samples = 4
+    C_src = md_test.source_competence()
     expected = np.array([[0.3], [0.0], [0.2], [-0.3]])
     assert np.allclose(C_src, expected, atol=0.01)
 
 
 """ Test the source_competence using the logarithmic method. Here we consider the same values 
-applied in the test_prob_functions.py to assert if the source_competence function call the ccprmod correctly
-and fill the competence source (C_src) with the correct results.
+applied in the test_prob_functions.py to assert if the source_competence function fill the competence source
+(C_src) with the correct results.
 
 The scores used are: [[0.67, 0.33, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
 The correct labels are: [1, 1, 1], so the supports for the correct class are: [0.33, 0.0, 1.0]
@@ -185,7 +195,10 @@ The expected value should be: an np.array (3,1) with the values = [[0.0], [-1.0]
 
 def test_source_competence_logarithmic():
     log_test = Logarithmic([create_base_classifier(return_value=1, return_prob=1.0)])
-    log_test.dsel_scores = np.array([[0.67, 0.33, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+    log_test.dsel_scores = np.array([[[0.67, 0.33, 0.0],
+                                     [1.0, 0.0, 0.0],
+                                     [0.0, 1.0, 0.0]]]).reshape(3, 1, 3)  # 3 sample, 1 classifier, 3 classes
+
     log_test.DSEL_target = [1, 1, 1]
     log_test.n_classes = 3
     log_test.n_samples = 3
@@ -195,8 +208,8 @@ def test_source_competence_logarithmic():
 
 
 """ Test the source_competence using the exponential method. Here we consider the same values 
-applied in the test_prob_functions.py to assert if the source_competence function call the ccprmod correctly
-and fill the competence source (C_src) with the correct results.
+applied in the test_prob_functions.py to assert if the source_competence function fill the competence source
+(C_src) with the correct results. 
 
 Only two classes are considered in this example.
 The scores used are: [[0.5, 0.5], [1.0, 0.0], [0.0, 1.0]].
@@ -207,7 +220,10 @@ The expected value should be: an np.array (3,1) with the values = [[0.0], [-1.0]
 
 def test_source_competence_exponential():
     exp_test = Exponential([create_base_classifier(return_value=1, return_prob=1.0)])
-    exp_test.dsel_scores = np.array([[0.5, 0.5], [1.0, 0.0], [0.0, 1.0]])
+    exp_test.dsel_scores = np.array([[[0.5, 0.5],
+                                     [1.0, 0.0],
+                                     [0.0, 1.0]]]).reshape(3, 1, 2)  # 3 samples, 1 classifier, 2 classes
+
     exp_test.DSEL_target = [1, 1, 1]
     exp_test.n_classes = 2
     exp_test.n_samples = 3

--- a/deslib/tests/examples_test.py
+++ b/deslib/tests/examples_test.py
@@ -25,21 +25,7 @@ neighbors_ex1 = np.array([[8, 11,  4,  7, 13, 10,  1],
                          [5,  3,  4,  8, 10, 11,  7]])
 
 # Scores obtained for the two classes. This information is used by the techniques based on posterior probabilities
-dsel_scores_ex1 = np.array([[1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2],
-                            [1.0, 0.0, 0.5, 0.5, 0.8, 0.2]])
+dsel_scores_ex1 = np.tile(np.array([[1.0, 0.0], [0.5, 0.5], [0.8, 0.2]]), (15, 1, 1))
 
 # Distance information is used by the probabilistic techniques (des.probabilistic) as well as the MLA, A Priori and
 # A Posteriori methods. Three values are considered: all zeros, all ones and the real distances calculated on the toy
@@ -53,7 +39,7 @@ distances_ex1 = np.array([[0.35355339, 0.35355339, 0.55901699, 0.79056942, 0.790
 
 dsel_processed_all_ones = np.ones((15, 3))
 
-dsel_scores_all_ones = np.ones((15, 6))
+dsel_scores_all_ones = np.ones((15, 3, 2))
 
 distances_all_ones = np.ones((3, 7))
 
@@ -61,7 +47,7 @@ distances_all_ones = np.ones((3, 7))
 
 dsel_processed_all_zeros = np.zeros((15, 3))
 
-dsel_scores_all_zeros = np.zeros((15, 6))
+dsel_scores_all_zeros = np.zeros((15, 3, 2))
 
 distances_all_zeros = np.zeros((3, 7))
 
@@ -89,7 +75,7 @@ dsel_processed_kuncheva = np.transpose(np.array([[1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 
 
 # scores obtained by each class by the base classifier ci. In this example we consider that the posteriori is always 1
 # fo the predicted class
-dsel_scores_ex_kuncheva = np.array([[0.0, 1.0, 0.0],
+dsel_scores_ex_kuncheva = np.array([[[0.0, 1.0, 0.0],
                                    [0.0, 0.0, 1.0],
                                    [0.0, 1.0, 0.0],
                                    [0.0, 1.0, 0.0],
@@ -103,7 +89,7 @@ dsel_scores_ex_kuncheva = np.array([[0.0, 1.0, 0.0],
                                    [0.0, 1.0, 0.0],
                                    [0.0, 1.0, 0.0],
                                    [0.0, 1.0, 0.0],
-                                   [1.0, 0.0, 0.0]])
+                                   [1.0, 0.0, 0.0]]]).reshape(15, 1, 3)  # 15 samples, 1 classifier, 3 classes
 
 k_ex_kuncheva = 15
 

--- a/deslib/tests/test_base.py
+++ b/deslib/tests/test_base.py
@@ -200,25 +200,9 @@ def test_preprocess_dsel_scores():
     ds_test = DS(create_pool_classifiers())
     ds_test.fit(X_dsel_ex1, y_dsel_ex1)
     dsel_scores = ds_test._preprocess_dsel_scores()
-    expected = np.ones((15, 6)) * np.array([0.5, 0.5, 1.0, 0.0, 0.33, 0.67])
+    expected = np.array([[0.5, 0.5], [1.0, 0.0], [0.33, 0.67]])
+    expected = np.tile(expected, (15, 1, 1))
     assert np.array_equal(dsel_scores, expected)
-
-
-def test_get_dsel_scores():
-    ds_test = DS(create_pool_classifiers())
-    ds_test.fit(X_dsel_ex1, y_dsel_ex1)
-    ds_test.dsel_scores = dsel_scores_ex1
-    assert np.array_equal(ds_test._get_scores_dsel(0, 0), np.array([1.0, 0.0]))
-    assert np.array_equal(ds_test._get_scores_dsel(1, 0), np.array([0.5, 0.5]))
-    assert np.array_equal(ds_test._get_scores_dsel(2, 0), np.array([0.8, 0.2]))
-
-
-def test_get_dsel_scores_all_samples():
-    ds_test = DS(create_pool_classifiers())
-    ds_test.fit(X_dsel_ex1, y_dsel_ex1)
-    ds_test.dsel_scores = dsel_scores_ex1
-    expected = np.ones((15, 2)) * 0.5
-    assert np.array_equal(ds_test._get_scores_dsel(1), expected)
 
 
 def test_get_dsel_scores_not_processed():
@@ -274,7 +258,7 @@ def test_predict_proba_all_agree():
     ds_test.dsel_scores = dsel_scores_ex1
     ds_test._all_classifier_agree = MagicMock(return_value=True)
     proba = ds_test.predict_proba(query)
-    assert np.isclose(proba, np.atleast_2d([0.61, 0.39])).all()
+    assert np.allclose(proba, np.atleast_2d([0.61, 0.39]))
 
 
 # In this test, the three neighborhoods have an hardness level lower than the parameter IH_rate (0.5). Thus, the KNN
@@ -291,7 +275,7 @@ def test_predict_proba_IH_knn(index):
 
     ds_test.roc_algorithm.predict_proba = MagicMock(return_value=np.atleast_2d([0.45, 0.55]))
     proba = ds_test.predict_proba(query)
-    assert np.isclose(proba, np.atleast_2d([0.45, 0.55])).all()
+    assert np.allclose(proba, np.atleast_2d([0.45, 0.55]))
 
 
 # In this test, the three neighborhoods have an hardness level higher than the parameter IH_rate. Thus, the prediction
@@ -307,7 +291,7 @@ def test_predict_proba_instance_called(index):
 
     ds_test.predict_proba_instance = MagicMock(return_value=np.atleast_2d([0.25, 0.75]))
     proba = ds_test.predict_proba(query)
-    assert np.isclose(proba, np.atleast_2d([0.25, 0.75])).all()
+    assert np.allclose(proba, np.atleast_2d([0.25, 0.75]))
 
 
 # In this test, the frienemy pruning is used. So, the value of self.DFP_mask should change.

--- a/deslib/tests/test_base.py
+++ b/deslib/tests/test_base.py
@@ -1,6 +1,5 @@
 import pytest
 from sklearn.exceptions import NotFittedError
-from sklearn.linear_model import Perceptron
 from unittest.mock import Mock
 
 from deslib.base import DS
@@ -205,13 +204,6 @@ def test_preprocess_dsel_scores():
     assert np.array_equal(dsel_scores, expected)
 
 
-def test_get_dsel_scores_not_processed():
-    ds_test = DS(create_pool_classifiers())
-    ds_test.fit(X_dsel_ex1, y_dsel_ex1)
-    with pytest.raises(NotFittedError):
-        ds_test._get_scores_dsel(0)
-
-
 def test_DFP_is_used():
     query = np.atleast_2d([1, 0])
     ds_test = DS(create_pool_classifiers(), DFP=True, safe_k=3)
@@ -337,7 +329,6 @@ def test_label_encoder_only_dsel_allagree():
     ds_test.distances = distances_ex1[0, :]
     predictions = ds_test.predict(query)
     assert np.array_equal(predictions, ['dog', 'dog'])
-
 
 
 def test_label_encoder_only_dsel():


### PR DESCRIPTION
Changing the dsel_scores array with the pre-processed scores of the base classifier to 3D (n_samples, n_classifier, n_classes) instead of a 2D shape. This closes issue #52 