### PR TITLE
Lazy initialization for the FAISS library

### DIFF
--- a/deslib/base.py
+++ b/deslib/base.py
@@ -15,6 +15,7 @@ from sklearn.ensemble import BaseEnsemble, BaggingClassifier
 from sklearn.neighbors import KNeighborsClassifier
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils.validation import check_X_y, check_is_fitted, check_array, check_random_state
+from deslib.util import faiss_knn_wrapper
 
 from deslib.util.instance_hardness import hardness_region_competence
 import warnings
@@ -45,6 +46,11 @@ class BaseDS(BaseEstimator, ClassifierMixin):
         self.knn_classifier = knn_classifier
         self.DSEL_perc = DSEL_perc
 
+        # Check optional dependency
+        if knn_classifier == 'faiss' and not faiss_knn_wrapper.is_available():
+            raise ImportError('Using knn_classifier="faiss" requires that the FAISS library '
+                              'be installed.Please check the Installation Guide.')
+
     def _set_region_of_competence_algorithm(self):
 
         if self.knn_classifier is None:
@@ -53,8 +59,8 @@ class BaseDS(BaseEstimator, ClassifierMixin):
         elif isinstance(self.knn_classifier, str):
 
             if self.knn_classifier == "faiss":
-                from deslib.util.faiss_knn_wrapper import FaissKNNClassifier
-                self.knn_class_ = functools.partial(FaissKNNClassifier, n_jobs=-1, algorithm="auto")
+                self.knn_class_ = functools.partial(faiss_knn_wrapper.FaissKNNClassifier,
+                                                    n_jobs=-1, algorithm="auto")
 
             elif self.knn_classifier == "knn":
                 self.knn_class_ = functools.partial(KNeighborsClassifier, n_jobs=-1, algorithm="auto")

--- a/deslib/tests/test_base.py
+++ b/deslib/tests/test_base.py
@@ -108,7 +108,6 @@ def test_import_faiss_mode():
     with unittest.mock.patch.dict('sys.modules', {'faiss': None}):
         with pytest.raises(ImportError):
             ds = BaseDS(create_pool_classifiers(), knn_classifier="faiss")
-            ds.fit(X_dsel_ex1, y_dsel_ex1)
 
 
 def test_none_selection_mode():

--- a/deslib/tests/test_base.py
+++ b/deslib/tests/test_base.py
@@ -107,7 +107,6 @@ def test_import_faiss_mode():
         pass
     with unittest.mock.patch.dict('sys.modules', {'faiss': None}):
         with pytest.raises(ImportError):
-
             ds = BaseDS(create_pool_classifiers(), knn_classifier="faiss")
             ds.fit(X_dsel_ex1, y_dsel_ex1)
 

--- a/deslib/tests/test_des_integration.py
+++ b/deslib/tests/test_des_integration.py
@@ -33,6 +33,7 @@ from deslib.static.static_selection import StaticSelection
 from sklearn.model_selection import GridSearchCV
 import pytest
 import warnings
+from deslib.util import faiss_knn_wrapper
 import sys
 
 
@@ -53,10 +54,9 @@ def test_grid_search():
 
 knn_methods = [None]
 
-try:
-    from deslib.util.faiss_knn_wrapper import FaissKNNClassifier
-    knn_methods.append(FaissKNNClassifier)
-except ImportError:
+if faiss_knn_wrapper.is_available():
+    knn_methods.append(faiss_knn_wrapper.FaissKNNClassifier)
+else:
     warnings.warn("Not testing FAISS for KNN")
 
 

--- a/deslib/tests/test_faiss.py
+++ b/deslib/tests/test_faiss.py
@@ -4,14 +4,10 @@ import sys
 from sklearn.neighbors import KNeighborsClassifier
 from deslib.tests.examples_test import *
 from deslib.tests.test_des_integration import load_dataset
-
-try:
-    from deslib.util.faiss_knn_wrapper import FaissKNNClassifier
-except ImportError:
-    pass
+from deslib.util import faiss_knn_wrapper
 
 
-@pytest.mark.skipif('faiss' not in sys.modules,
+@pytest.mark.skipif(not faiss_knn_wrapper.is_available(),
                     reason="requires the faiss library")
 def test_faiss_predict():
     rng = np.random.RandomState(123456)
@@ -19,7 +15,7 @@ def test_faiss_predict():
     k = 7
     X_train = X_train.astype(np.float32)
     X_test = X_test.astype(np.float32)
-    f_knn_test = FaissKNNClassifier(n_neighbors=k)
+    f_knn_test = faiss_knn_wrapper.FaissKNNClassifier(n_neighbors=k)
     f_knn_test.fit(X_train, y_train)
     f_knn_preds = f_knn_test.predict(X_test)
 

--- a/deslib/util/faiss_knn_wrapper.py
+++ b/deslib/util/faiss_knn_wrapper.py
@@ -4,8 +4,15 @@
 #
 # License: BSD 3 clause
 
-import faiss
 import numpy as np
+
+
+def is_available():
+    try:
+        import faiss
+        return True
+    except ImportError:
+        return False
 
 
 class FaissKNNClassifier:
@@ -36,6 +43,9 @@ class FaissKNNClassifier:
         self.y = None
         self.num_of_classes = None
         self.index = None
+
+        import faiss
+        self.faiss = faiss
 
     def predict(self, X):
         """Predict the class label for each sample in X.
@@ -100,7 +110,7 @@ class FaissKNNClassifier:
         """
         X = np.atleast_2d(X).astype(np.float32)
         X = np.ascontiguousarray(X)
-        self.index = faiss.IndexFlatL2(X.shape[1])
+        self.index = self.faiss.IndexFlatL2(X.shape[1])
         self.index.add(X)
         self.y = y
         self.num_of_classes = np.max(self.y) + 1


### PR DESCRIPTION
Allow the faiss_knn_wrapper to always be imported (even if faiss is not installed) - so that docs can be built. new function "is_available" checks if faiss is installed.