### PR TITLE
Update knora_e.py

### DIFF
--- a/deslib/des/knora_e.py
+++ b/deslib/des/knora_e.py
@@ -167,7 +167,7 @@ class KNORAE(BaseDES):
         # corresponding to the first occurrence are returned.
         competences = np.argmax(results_neighbors == 0, axis=1)
 
-        return competences.astype(np.float)
+        return competences.astype(np.float64)
 
     def select(self, competences):
         """Selects all base classifiers that obtained a local accuracy of 100%


### PR DESCRIPTION
AttributeError: module 'numpy' has no attribute 'float'. `np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here. The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations